### PR TITLE
fix bug with inserting before first element in linked list

### DIFF
--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -185,6 +185,13 @@ pub fn print_result<'a>(
 fn list_insert_ordered(mut list: LinkedList<BestLayoutsEntry>, entry: BestLayoutsEntry)
 -> LinkedList<BestLayoutsEntry>
 {
+	if let Some(first) = list.front() {
+		let cmp = entry.cmp(first);
+		if cmp == Ordering::Less {
+			list.push_front(entry);
+			return list;
+		}
+	}
 	{
 		// Find where to add our new entry to, since the list is sorted.
 		let mut cursor = list.cursor_front_mut();


### PR DESCRIPTION
running: `cargo run -- run corpus/books.veryshort.txt -t 5`

before this change: (first entry in linked list is out of order)

```
j c y f k | z l , r q =
u s t h d | m n a i o '
/ v g p b | x w . ; -
        e |
total: 196913.375; scaled: 0.7212310089955462
base: 146471  /  l: 13255.5; d: 13209; r: 11420; o: 7946.5; w: 6943.5;
same finger: 15995  /  ri: 4520; ir: 2145; wn: 1170; ty: 910; nl: 860;
long jump hand: 1163  /  r.: 214; by: 179; lw: 88; w,: 85; l.: 84;
long jump: 1810  /  lw: 880; wl: 370; r:: 270; r;: 200; gy: 80;
long jump consecutive: 1345  /  r.: 1070; r-: 170; vy: 50; -r: 45; .z: 5;
pinky/ring twist: 0  /
roll reversal: 1400  /  cut: 560; aor: 200; sug: 180; roa: 140; tuc: 60;
same hand: 11349  /  , an: 307;  in : 301.5;  Ali: 162; all : 156.5;  all: 122;
alternating hand: 19183  /   you: 439.5; hat : 384.5; you : 258.5; his : 225.5; ould: 178;
roll out: 2480  /  ar: 188.875; li: 168.625; ai: 136.625; wa: 135.625; no: 111.25;
roll in: -8361.625  /  he: -750.5; th: -702.125; in: -463.875; , : -385.625; an: -373.75;
long jump sandwich: 3069  /  low: 381; wil: 357; wel: 204; Gry: 165; bef: 162;
twist: 1010  /  war: 690; raw: 220; -al: 40; WAR: 30; ys?: 10;

; ' h . / | z f w g j =
o a n i , | d t r l s y
x q b u - | k m c v p
        e |
total: 176688.125; scaled: 0.6471523565693859
base: 145395  /  d: 13209; h: 12706; u: 9822; y: 9432; a: 8038.5;
same finger: 10835  /  cr: 1110; ui: 880; sp: 795; ys: 720; ft: 690;
long jump hand: 483  /  hu: 86; "B: 53; -': 47; u': 45; u.: 30;
long jump: 810  /  u.: 300; u?: 150; mf: 110; ?-: 60; hb: 50;
long jump consecutive: 440  /  "B: 265; "b: 125; pg: 20; b.: 10; PG: 5;
pinky/ring twist: 10  /  a;: 10;
roll reversal: 1420  /  "Oh: 700; "On: 200; rpl: 180; hoa: 80; "on: 80;
same hand: 3586  /  abou: 80.5; ll t: 58.5;  my : 58.5; lly : 46; been: 45.5;
alternating hand: 16903  /  lice: 199; with: 197.5; Alic: 197.5; ere : 169; ith : 166.5;
roll out: 2359.875  /  in: 463.875; ha: 272.125; ho: 115; no: 111.25; ly: 102.25;
roll in: -6699.75  /  he: -750.5; t : -598.125; d : -592.75; s : -443.875; an: -373.75;
long jump sandwich: 1146  /  f m: 150; giv: 123; us.: 84; beh: 78; gav: 63;
twist: 0  /

/ ' h . ; | z f w g j =
o a n i , | d t r l s y
x q b u - | k m c v p
        e |
total: 177078; scaled: 0.6485803445850914
base: 145395  /  d: 13209; h: 12706; u: 9822; y: 9432; a: 8038.5;
same finger: 10805  /  cr: 1110; ui: 880; sp: 795; ys: 720; ft: 690;
long jump hand: 483  /  hu: 86; "B: 53; -': 47; u': 45; u.: 30;
long jump: 760  /  u.: 300; :-: 160; mf: 110; hb: 50; .u: 40;
long jump consecutive: 440  /  "B: 265; "b: 125; pg: 20; b.: 10; PG: 5;
pinky/ring twist: 20  /  a?: 10; /a: 10;
roll reversal: 1920  /  "Oh: 700; n?': 300; "On: 200; rpl: 180; n?": 100;
same hand: 3586  /  abou: 80.5;  my : 58.5; ll t: 58.5; lly : 46; been: 45.5;
alternating hand: 16903  /  lice: 199; with: 197.5; Alic: 197.5; ere : 169; ith : 166.5;
roll out: 2327.875  /  in: 463.875; ha: 272.125; ho: 115; no: 111.25; ly: 102.25;
roll in: -6732.875  /  he: -750.5; t : -598.125; d : -592.75; s : -443.875; an: -373.75;
long jump sandwich: 1161  /  f m: 150; giv: 123; us.: 84; beh: 78; gav: 63;
twist: 10  /  un?: 10;

/ ' h . ; | z f w g j =
o a n i , | d t r l s y
x q b u - | k m c v p
        e |
total: 177078; scaled: 0.6485803445850914
base: 145395  /  d: 13209; h: 12706; u: 9822; y: 9432; a: 8038.5;
same finger: 10805  /  cr: 1110; ui: 880; sp: 795; ys: 720; ft: 690;
long jump hand: 483  /  hu: 86; "B: 53; -': 47; u': 45; u.: 30;
long jump: 760  /  u.: 300; :-: 160; mf: 110; hb: 50; .u: 40;
long jump consecutive: 440  /  "B: 265; "b: 125; pg: 20; b.: 10; gp: 5;
pinky/ring twist: 20  /  /a: 10; a?: 10;
roll reversal: 1920  /  "Oh: 700; n?': 300; "On: 200; rpl: 180; n?": 100;
same hand: 3586  /  abou: 80.5;  my : 58.5; ll t: 58.5; lly : 46; been: 45.5;
alternating hand: 16903  /  lice: 199; with: 197.5; Alic: 197.5; ere : 169; ith : 166.5;
roll out: 2327.875  /  in: 463.875; ha: 272.125; ho: 115; no: 111.25; ly: 102.25;
roll in: -6732.875  /  he: -750.5; t : -598.125; d : -592.75; s : -443.875; an: -373.75;
long jump sandwich: 1161  /  f m: 150; giv: 123; us.: 84; beh: 78; gav: 63;
twist: 10  /  un?: 10;

/ ' h . ; | z f w g j =
a o n i , | d t r l s y
x q b u - | k m c v p
        e |
total: 177686.875; scaled: 0.6508104598863104
base: 145395  /  d: 13209; h: 12706; u: 9822; y: 9432; a: 8038.5;
same finger: 10550  /  cr: 1110; ui: 880; sp: 795; ys: 720; ft: 690;
long jump hand: 483  /  hu: 86; "B: 53; -': 47; u': 45; u.: 30;
long jump: 760  /  u.: 300; :-: 160; mf: 110; hb: 50; .u: 40;
long jump consecutive: 440  /  "B: 265; "b: 125; pg: 20; b.: 10; Q.: 5;
pinky/ring twist: 120  /  o?: 110; O?: 10;
roll reversal: 2660  /  "an: 940; "An: 620; n?': 300; "Ah: 260; rpl: 180;
same hand: 3586  /  abou: 80.5; ll t: 58.5;  my : 58.5; lly : 46; been: 45.5;
alternating hand: 16903  /  lice: 199; with: 197.5; Alic: 197.5; ere : 169; ith : 166.5;
roll out: 2343  /  in: 463.875; ha: 272.125; ho: 115; no: 111.25; ly: 102.25;
roll in: -6724.125  /  he: -750.5; t : -598.125; d : -592.75; s : -443.875; an: -373.75;
long jump sandwich: 1161  /  f m: 150; giv: 123; us.: 84; beh: 78; gav: 63;
twist: 10  /  un?: 10;
```

after this change:
```

/ d y v z | j ' m w - =
i s e n p | l h t u a ,
b c k f q | x r g ; .
          | o
total: 191977.625; scaled: 0.7031529279477262
base: 146660  /  r: 17130; l: 13255.5; d: 8806; c: 8698; ,: 8224;
same finger: 15305  /  ke: 3225; ey: 1905; rl: 1270; ye: 915; ds: 855;
long jump hand: 1456  /  .": 253; rm: 195; .': 189; by: 179; m.: 99;
long jump: 1020  /  'r: 380; r': 210; ky: 160; "R: 130; cd: 40;
long jump consecutive: 610  /  w.: 270; cy: 110; :-: 80; g': 35; yc: 35;
pinky/ring twist: 580  /  s?: 280; :-: 160; u-: 80; -u: 50; /S: 10;
roll reversal: 2860  /  die: 660; wat: 580; cie: 520; tau: 140; kis: 120;
same hand: 12035.5  /  that: 307;  in : 301.5;  is : 188.5; ice : 133; ough: 116.5;
alternating hand: 13928  /  , an: 307;  her: 238.5; her : 228;  wit: 184; here: 140.5;
roll out: 3391.25  /  nd: 279.5; ha: 272.125; ed: 229.75; ve: 176.5; es: 155.125;
roll in: -8504.125  /  e : -1013.375; th: -702.125; d : -592.75; in: -463.875; s : -443.875;
long jump sandwich: 2376  /  d c: 270; Duc: 147; mig: 129; g m: 123; ced: 117;
twist: 260  /  def: 90; -tr: 70; Def: 40; rt-: 20; fed: 20;

/ d y v z | x ' m w - =
i s e n p | l h t u a ,
b c k f q | j r g ; .
          | o
total: 192075.625; scaled: 0.7035118707512893
base: 146711  /  r: 17130; l: 13255.5; d: 8806; c: 8698; ,: 8224;
same finger: 15305  /  ke: 3225; ey: 1905; rl: 1270; ye: 915; ds: 855;
long jump hand: 1473  /  .": 253; rm: 195; .': 189; by: 179; m.: 99;
long jump: 1080  /  'r: 380; r': 210; ky: 160; "R: 130; "J: 40;
long jump consecutive: 610  /  w.: 270; cy: 110; :-: 80; g': 35; yc: 35;
pinky/ring twist: 580  /  s?: 280; :-: 160; u-: 80; -u: 50; /S: 10;
roll reversal: 2860  /  die: 660; wat: 580; cie: 520; tau: 140; kis: 120;
same hand: 12035.5  /  that: 307;  in : 301.5;  is : 188.5; ice : 133; ough: 116.5;
alternating hand: 13928  /  , an: 307;  her: 238.5; her : 228;  wit: 184; here: 140.5;
roll out: 3391.25  /  nd: 279.5; ha: 272.125; ed: 229.75; ve: 176.5; es: 155.125;
roll in: -8504.125  /  e : -1013.375; th: -702.125; d : -592.75; in: -463.875; s : -443.875;
long jump sandwich: 2256  /  d c: 270; Duc: 147; mig: 129; g m: 123; ced: 117;
twist: 350  /  def: 90; -tr: 70; xt.: 60; Def: 40; .tx: 30;

/ d y v q | x ' m w - =
i s e n p | l h t u a ,
b c k f z | j r g ; .
          | o
total: 192338.125; scaled: 0.7044733246894046
base: 146815.5  /  r: 17130; l: 13255.5; d: 8806; c: 8698; ,: 8224;
same finger: 15305  /  ke: 3225; ey: 1905; rl: 1270; ye: 915; ds: 855;
long jump hand: 1481  /  .": 253; rm: 195; .': 189; by: 179; m.: 99;
long jump: 1080  /  'r: 380; r': 210; ky: 160; "R: 130; cd: 40;
long jump consecutive: 630  /  w.: 270; cy: 110; :-: 80; g': 35; yc: 35;
pinky/ring twist: 580  /  s?: 280; :-: 160; u-: 80; -u: 50; /S: 10;
roll reversal: 2860  /  die: 660; wat: 580; cie: 520; tau: 140; kis: 120;
same hand: 12035.5  /  that: 307;  in : 301.5;  is : 188.5; ice : 133; ough: 116.5;
alternating hand: 13928  /  , an: 307;  her: 238.5; her : 228;  wit: 184; here: 140.5;
roll out: 3391.25  /  nd: 279.5; ha: 272.125; ed: 229.75; ve: 176.5; es: 155.125;
roll in: -8504.125  /  e : -1013.375; th: -702.125; d : -592.75; in: -463.875; s : -443.875;
long jump sandwich: 2256  /  d c: 270; Duc: 147; mig: 129; g m: 123; ced: 117;
twist: 480  /  zed: 120; def: 90; -tr: 70; xt.: 60; Def: 40;

/ d y v q | x ' m w - =
i s e n p | l h t u a ,
b c k f z | j r g ; .
          | o
total: 192338.125; scaled: 0.7044733246894046
base: 146815.5  /  r: 17130; l: 13255.5; d: 8806; c: 8698; ,: 8224;
same finger: 15305  /  ke: 3225; ey: 1905; rl: 1270; ye: 915; ds: 855;
long jump hand: 1481  /  .": 253; rm: 195; .': 189; by: 179; m.: 99;
long jump: 1080  /  'r: 380; r': 210; ky: 160; "R: 130; "J: 40;
long jump consecutive: 630  /  w.: 270; cy: 110; :-: 80; yc: 35; g': 35;
pinky/ring twist: 580  /  s?: 280; :-: 160; u-: 80; -u: 50; /S: 10;
roll reversal: 2860  /  die: 660; wat: 580; cie: 520; tau: 140; kis: 120;
same hand: 12035.5  /  that: 307;  in : 301.5;  is : 188.5; ice : 133; ough: 116.5;
alternating hand: 13928  /  , an: 307;  her: 238.5; her : 228;  wit: 184; here: 140.5;
roll out: 3391.25  /  nd: 279.5; ha: 272.125; ed: 229.75; ve: 176.5; es: 155.125;
roll in: -8504.125  /  e : -1013.375; th: -702.125; d : -592.75; in: -463.875; s : -443.875;
long jump sandwich: 2256  /  d c: 270; Duc: 147; mig: 129; g m: 123; ced: 117;
twist: 480  /  zed: 120; def: 90; -tr: 70; xt.: 60; Def: 40;

/ d y v q | x ' g w - =
i s e n p | l h t u a ,
b c k f z | j r m ; .
          | o
total: 192877.125; scaled: 0.7064475101090014
base: 146920.5  /  r: 17130; l: 13255.5; d: 8806; c: 8698; ,: 8224;
same finger: 15305  /  ke: 3225; ey: 1905; rl: 1270; ye: 915; ds: 855;
long jump hand: 1900  /  gr: 263; .": 253; .': 189; by: 179; Gr: 154;
long jump: 1080  /  'r: 380; r': 210; ky: 160; "R: 130; "J: 40;
long jump consecutive: 645  /  w.: 270; cy: 110; :-: 80; g;: 50; yc: 35;
pinky/ring twist: 580  /  s?: 280; :-: 160; u-: 80; -u: 50; /S: 10;
roll reversal: 2860  /  die: 660; wat: 580; cie: 520; tau: 140; kis: 120;
same hand: 12035.5  /  that: 307;  in : 301.5;  is : 188.5; ice : 133; ough: 116.5;
alternating hand: 13928  /  , an: 307;  her: 238.5; her : 228;  wit: 184; here: 140.5;
roll out: 3391.25  /  nd: 279.5; ha: 272.125; ed: 229.75; ve: 176.5; es: 155.125;
roll in: -8504.125  /  e : -1013.375; th: -702.125; d : -592.75; in: -463.875; s : -443.875;
long jump sandwich: 2256  /  d c: 270; Duc: 147; mig: 129; g m: 123; ced: 117;
twist: 480  /  zed: 120; def: 90; -tr: 70; xt.: 60; Def: 40;
```