### PR TITLE
fix bug in refine

### DIFF
--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -112,7 +112,7 @@ pub fn refine<'a>(
 	loop {
 		// Test every layout within `num_swaps` swaps of the initial layout.
 		let mut best_layouts: LinkedList<BestLayoutsEntry> = LinkedList::new();
-		let permutations = layout::LayoutPermutations::new(init_layout, num_swaps);
+		let permutations = layout::LayoutPermutations::new(&curr_layout, num_swaps);
 		for (i, layout) in permutations.enumerate() {
 			let penalty = penalty::calculate_penalty(&quartads, len, &layout, penalties, false);
 


### PR DESCRIPTION
I was running refine a bunch of times (I'm using your code to find some optimized layout for mobile/android) and I found the refine only would go one step further each time.

With this change, now the refine correctly does a hill-climb, and for me it did like 10 iterations of hill climbing; each time with a better score, then finally terminated. And when I ran the refine a second time with the updated best layout, it didn't find any improvements (good - we are at local min for the second run)